### PR TITLE
Fix: Missing response URL

### DIFF
--- a/resources/js/components/ImageHotspots.vue
+++ b/resources/js/components/ImageHotspots.vue
@@ -221,7 +221,7 @@ export default {
 					.then((response) => {
 						if (allowFileTypes.includes(response.data[0].extension)) {
 							this.data.imageFile = {
-								url: response.data[0].url,
+								url: response.data[0].url ?? response.data[0].downloadUrl,
 								id: response.data[0].id,
 								fileName: response.data[0].basename,
 								alt: response.data[0].values.alt,


### PR DESCRIPTION
Currently, the `response` object may have a null `url` attribute, even when a `downloadUrl` is available (e.g., in my case when using the S3 filesystem). This PR addresses the issue by ensuring the code properly checks for and utilizes `downloadUrl` when `url` is null.