### PR TITLE
Fix: handle global field arrays and field objects in image_hot_spots tag

### DIFF
--- a/src/Tags/HotSpotImageTag.php
+++ b/src/Tags/HotSpotImageTag.php
@@ -23,15 +23,24 @@ class HotSpotImageTag extends Tags
                 return '';
             }
 
-            $data = $this->context->get($field)->value();
+            $contextValue = $this->context->get($field);
 
-            if (!$data) {
+            // Handle both field objects and direct data arrays
+            if (is_object($contextValue) && method_exists($contextValue, 'value')) {
+                // This is a field object (page-level field)
+                $data = $contextValue->value();
+            } else {
+                // This is direct data (global field reference)
+                $data = $contextValue;
+            }
+
+            if (!$data || !is_array($data)) {
                 return '';
             }
 
             return [
-                'image' => $data['imageFile'],
-                'hotspots' => $data['hotspots'],
+                'image' => $data['imageFile'] ?? null,
+                'hotspots' => $data['hotspots'] ?? [],
             ];
 
         } catch (\Exception $e) {


### PR DESCRIPTION
## Fix: Handle global field arrays and field objects in image_hot_spots tag

### Problem
When using global field references like `maps:visitor_trail_hot_spots`, the tag fails with:
- `Call to a member function value() on array` 
- `array_key_exists(): Argument #1 ($key) must be a valid array offset type`

### Solution
Modified `HotSpotImageTag.php` to handle both:
- **Field objects** (page-level fields): Calls `->value()` method as before
- **Direct data arrays** (global field references): Uses the data directly

### Usage Examples
```antlers
<!-- Page-level field (existing functionality) -->
{{ image_hot_spots field="image_hot_spots_field" }}

<!-- Global field reference (new functionality) -->
{{ image_hot_spots field="maps:visitor_trail_hot_spots" }}
```

### Backward Compatibility
✅ Fully backward compatible - no breaking changes
✅ Existing implementations continue to work unchanged